### PR TITLE
front matter(---) を翻訳しないように修正

### DIFF
--- a/src/cmark_xml.rs
+++ b/src/cmark_xml.rs
@@ -20,13 +20,14 @@ pub fn read_cmark_with_frontmatter<R: std::io::Read>(
         && (src_path.extension().unwrap() == "md" || src_path.extension().unwrap() == "mdx")
     {
         // Markdown file
-        Ok((buf, None))
+        if buf.starts_with("---") {
+            split_frontmatter(&buf, "---")
+        } else {
+            Ok((buf, None))
+        }
     } else if buf.starts_with("+++") {
         // TOML frontmatter
         split_frontmatter(&buf, "+++")
-    } else if buf.starts_with("---") {
-        // YAML frontmatter
-        split_frontmatter(&buf, "---")
     } else {
         // No frontmatter, only CommonMark body
         Ok((buf, None))

--- a/src/trans.rs
+++ b/src/trans.rs
@@ -27,7 +27,9 @@ pub async fn translate_cmark_file<P: AsRef<std::path::Path>>(
     // Parse frontmatter
     let translated_frontmatter = if let Some(frontmatter) = frontmatter {
         // translate TOML frontmatter
-        Some(translate_toml(&deepl, from_lang, to_lang, formality, &frontmatter).await?)
+        // Some(translate_toml(&deepl, from_lang, to_lang, formality, &frontmatter).await?)
+        // front matter は翻訳しない
+        Some(frontmatter)
     } else {
         None
     };
@@ -44,9 +46,9 @@ pub async fn translate_cmark_file<P: AsRef<std::path::Path>>(
     // Print result
     let mut f = std::fs::File::create(&dst_path)?;
     if let Some(translated_frontmatter) = translated_frontmatter {
-        f.write_all("+++\n".as_bytes())?;
+        f.write_all("---\n".as_bytes())?;
         f.write_all(translated_frontmatter.as_bytes())?;
-        f.write_all("+++\n".as_bytes())?;
+        f.write_all("---\n".as_bytes())?;
     }
     f.write_all(translated_cmark.as_bytes())?;
     f.write_all("\n<!---\n".as_bytes())?;


### PR DESCRIPTION
markdown の front matter の部分を翻訳しないように修正しました。

例
$ cargo run --  translate --formality formal -f en -t ja ../portal/docs/developer-docs/setup/install/

下記を翻訳せずに出力

```
---
sidebar_position: 2
---
```